### PR TITLE
add description to metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "hyxos_numerals"
 authors = ["Donnie Hyxos"]
 homepage = "https://hyxos.io"
 repository = "https://github.com/hyxos/hyxos_numerals"
+description = "A library for working with the hyxos numerals."
 version = "0.1.0"
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
A description is necessary for publishing to crates.io.