### PR TITLE
Integrate comprehensive Hyxos grammar guide

### DIFF
--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -1,0 +1,437 @@
+# Hyxos Numeral System Grammar Guide
+
+## Overview
+
+This document outlines the grammar rules of the **Hyxos numeral system**, enabling counting from `zo` (0) to `zru` (~60^13). It defines the base glyphs, diacritics, suffix tiers, and contraction rules used in spoken and symbolic representations. This guide is designed for use by humans or AI systems to understand, generate, and parse Hyxos symbolic numerals.
+
+**Important**: The Hyxos system is designed as a pure numeral system that can be embedded within any existing language, similar to how terms like "dozen" or "score" function in English. This guide covers only numerical expressions - no verbs, sentence structure, or non-numeric vocabulary. Hyxos numbers can be used within English, Spanish, Mandarin, or any other language as a specialized counting system.
+
+### Terminology
+- **Hyxamel** (noun): A number expressed in the Hyxos numeral system, analogous to how "decimal" refers to base-10 numbers
+- **Decimal**: Traditional base-10 representation (e.g., 4689)
+- **Hyxadekimal** (adjective/noun): The base-60 numeral system itself, from hyxa (six) + dek (ten) + -imal, literally "six-ten-al" (Hyxos-native term using the system's own vocabulary)
+- **Maal** (adjective/noun): Pure Hyxos term for base-60/sexagesimal, from ma (60) + -al suffix
+- **Sexagesimal**: Latin-derived term for base-60 (traditional mathematical term)
+
+---
+
+## 1. Base Glyphs (0–11)
+
+| Decimal | Glyph  | Encoding |
+|---------|--------|----------|
+| 0       | zo     | 0        |
+| 1       | zee    | 1        |
+| 2       | bey    | 2        |
+| 3       | tree   | 3        |
+| 4       | kat    | 4        |
+| 5       | pen    | 5        |
+| 6       | hyx    | 6        |
+| 7       | sep    | 7        |
+| 8       | awk    | 8        |
+| 9       | neyn   | 9        |
+| 10      | dek    | a        |
+| 11      | lev    | b        |
+
+---
+
+## 2. Diacritics (12–59)
+
+Each diacritic represents a base-12 tier:
+
+| Tier | Diacritic | Starts At | Encoding |
+|------|-----------|-----------|----------|
+| 0    | ta        | 0         | t        |
+| 1    | she       | 12        | s        |
+| 2    | ree       | 24        | r        |
+| 3    | jo        | 36        | j        |
+| 4    | wu        | 48        | w        |
+
+### Encoding Methods
+
+1. **Two-Part Array Encoding**: [tier, offset] where tier is 0-4 and offset is 0-11
+   - `[1, 0]` = she (tier 1, offset 0 = decimal 12)
+   - `[1, 3]` = shetree (tier 1, offset 3 = decimal 15)
+   - `[2, 8]` = reek (tier 2, offset 8 = decimal 32)
+   - `[4, 0]` = wu (tier 4, offset 0 = decimal 48)
+   - `[4, 11]` = wulev (tier 4, offset 11 = decimal 59)
+
+2. **Decimal Calculation**: Decimal = (tier × 12) + offset
+   - `[1, 3]` = (1 × 12) + 3 = 15 = shetree
+   - `[2, 8]` = (2 × 12) + 8 = 32 = reek
+   - `[4, 11]` = (4 × 12) + 11 = 59 = wulev
+
+3. **Two-Character String Encoding**: Diacritic letter + glyph encoding
+   - 12 = **she** → `s0`
+   - 15 = **shetree** → `s3`
+   - 18 = **shex** → `s6` (with contraction)
+   - 32 = **reek** → `r8` (with contraction)
+   - 59 = **wulev** → `wb`
+
+---
+
+## 3. Contraction Rules
+
+### Contraction Glyphs
+
+For smoother pronunciation, glyphs `hyx` and `awk` contract with diacritics:
+
+| Diacritic | + hyx → | + awk →  |
+|-----------|---------|----------|
+| she       | shex    | shek     |
+| ree       | reex    | reek     |
+| jo        | jox     | jok      |
+| wu        | wux     | wuk      |
+
+---
+
+## 4. Suffix Tier System (60ⁿ and above)
+
+Suffixes denote powers of 60. Applied after 59:
+
+| Power | Decimal Value  | Suffix | Vowel   | 
+|-------|----------------|--------|--------|
+| 60^1  | 60             | ma     | a      |
+| 60^2  | 3,600          | fe     | e      |
+| 60^3  | 216,000        | gi     | i      |
+| 60^4  | 12.96M         | tho    | o      |
+| 60^5  | 777.6M         | vu     | u      |
+| 60^6  | 46.656B        | ya     | a      |
+| 60^7  | 2.799T         | fre    | e      |
+| 60^8  | 167.9T         | gli    | i      |
+| 60^9  | 10.1P          | dra    | a      |
+| 60^10 | 604P           | ske    | e      |
+| 60^11 | 36E            | pri    | i      |
+| 60^12 | 2.1Z           | kro    | o      |
+| 60^13 | 126.1Z         | zru    | u      |
+
+---
+
+## 5. Forming Numbers
+
+### Numbers 0–59:
+- Use base glyphs and diacritics.
+- No suffixes.
+- Apply contractions where needed.
+
+### Numbers ≥ 60:
+- Numbers follow the pattern: **[multiplier].[suffix].[remainder]**
+- When spoken, implicit elements are dropped:
+  - Implicit `ta` (multiplier = 1) is not spoken
+  - Implicit `zo` (remainder = 0) is not spoken
+  
+#### Deep Structure Examples:
+- 60 = `ta.ma.zo` → **ma** (drop implicit ta and zo)
+- 61 = `ta.ma.zee` → **mazee** (drop implicit ta)
+- 62 = `ta.ma.bey` → **mabey**
+- 71 = `ma.she.lev` → **mashelev** (60 + 11)
+- 84 = `ma.ree.awk` → **mareek** (60 + 24, with contraction)
+- 119 = `ma.wu.lev` → **mawulev** (60 + 59)
+- 120 = `bey.ma.zo` → **beyma** (2×60, drop zo)
+- 121 = `bey.ma.zee` → **beymazee**
+- 132 = `bey.ma.she.zo` → **beymashe** (2×60 + 12, drop zo)
+- 144 = `bey.ma.she.she` → **beymasheshe** (2×60 + 24)
+- 180 = `tree.ma.zo` → **treema** (3×60)
+- 3600 = `ta.fe.zo` → **fe** (1×3600)
+- 3660 = `ta.fe.ta.ma.zo` → **fema** (3600 + 60)
+- 3661 = `ta.fe.ta.ma.zee` → **femazee**
+- 7200 = `bey.fe.zo` → **beyfe** (2×3600)
+
+### Fundamental Pattern for Large Numbers
+
+The Hyxos system builds all numbers using a recursive pattern. Every number can be decomposed into individual tokens separated by periods:
+
+```
+[glyph].[suffix].[diacritic].[glyph]...
+```
+
+More specifically, for numbers with suffixes:
+- **Before suffix**: `[diacritic].[glyph]` or just `[glyph]` (multiplier)
+- **Suffix**: The power of 60 (ma, fe, gi, etc.)
+- **After suffix**: `[diacritic].[glyph]` or just `[glyph]` (remainder)
+
+Token separation rules:
+- Each diacritic is a separate token: `ta`, `she`, `ree`, `jo`, `wu`
+- Each glyph is a separate token: `zo`, `zee`, `bey`, etc.
+- Each suffix is a separate token: `ma`, `fe`, `gi`, etc.
+- In technical notation, ALL tokens are shown separated by periods
+- In spoken form, tokens merge following the contraction and dropping rules
+
+The remainder itself can contain another suffix, creating nested structures:
+- 3661 = `ta.fe.ta.ma.zee` → **femazee** (3600 + 60 + 1)
+
+### Suffix Interaction Rules
+
+When a suffix appears:
+1. It "captures" everything to its left as its multiplier
+2. Everything to its right becomes the remainder
+3. The pattern repeats recursively for nested suffixes
+
+Examples with explicit tokenization:
+- **beymashe** = `bey.ma.she.zo` = 2×60 + 12 = 132
+- **femabey** = `ta.fe.ta.ma.bey` = 1×3600 + 1×60 + 2 = 3662
+- **treefebeyma** = `tree.fe.bey.ma.zo` = 3×3600 + 2×60 = 10,920
+- **wulevmawulev** = `wu.lev.ma.wu.lev` = 59×60 + 59 = 3599
+
+---
+
+## 6. Counting Examples
+
+### Count by 3 (Tree) to 60:
+- 3 = **tree**
+- 6 = **hyx**
+- 9 = **neyn**
+- 12 = **she**
+- 15 = **shetree**
+- 18 = **shex**
+- ...
+- 60 = **ma**
+
+---
+
+## 7. Fractions
+
+### The Fraction Suffix: -os / -tos
+
+Fractions in Hyxos are formed by adding the suffix **-os** or **-tos** to form "one-nth". The choice between -os and -tos appears to follow euphonic patterns:
+
+Pattern observations:
+- **-tos**: zotos, zeetos, beytos, treetos, pentos, septos, awktos
+- **-os**: katos, hyxos, neynos, dekos, levos, shetos
+- The distribution may reflect phonetic harmony or historical linguistic patterns
+
+| Hyxamel | Meaning | Decimal |
+|---------|---------|---------|
+| zotos   | 1/0     | ∞       |
+| zeetos  | 1/1     | 1.0     |
+| beytos  | 1/2     | 0.5     |
+| treetos | 1/3     | ~0.333  |
+| katos   | 1/4     | 0.25    |
+| pentos  | 1/5     | 0.2     |
+| hyxos   | 1/6     | ~0.167  |
+| septos  | 1/7     | ~0.143  |
+| awktos  | 1/8     | 0.125   |
+| neynos  | 1/9     | ~0.111  |
+| dekos   | 1/10    | 0.1     |
+| levos   | 1/11    | ~0.091  |
+| shetos  | 1/12    | ~0.083  |
+
+### Compound Fractions
+
+For numerators greater than 1:
+- **beytreetos** = 2/3 = ~0.667
+- **treekatos** = 3/4 = 0.75
+- **shehyxos** = 12/6 = 2
+
+### Etymology Note
+
+The name "Hyxos" for the numeral system itself comes from **hyxos** (1/6), reflecting the hexagonal/six-fold symmetry that appears throughout the system's design.
+
+---
+
+## 8. Grammatical Suffixes (Provisional)
+
+### Core Suffix Pattern
+
+Following the diacritic vowel sequence (a, e, i, o, u), grammatical suffixes modify number meaning:
+
+| Suffix | Vowel   | Function          | Example      | Meaning                |
+|-------|---------|-------------------|--------------|------------------------|
+| -as   | a (ta)  | singular/cardinal | hyxas → hyx  | six (usually implicit) |
+| -es   | e (she) | plural            | hyxes        | sixes                  |
+| -is   | i (ree) | trio              | hyxis        | group of three         |
+| -os   | o (jo)  | fractional        | hyxos        | one-sixth              |
+| -us   | u (wu)  | ordinal           | hyxus        | sixth (in order)       |
+
+### Extended Patterns (Experimental)
+
+**Compound suffixes for numerical operations:**
+- **-ema** - iterative/repeated (e.g., beyema = "twice/repeatedly")
+- **-ek** - reciprocal/pairwise (e.g., beyek = "in pairs", treek = "in triples")
+- **-an** - multiplicative (e.g., hyxan = "sixfold", dekan = "tenfold")
+- **-at** - distributive (e.g., hyxat = "by sixes", mawat = "by sixties")
+- **-ar** - approximative (e.g., dekar = "about ten", fear = "roughly 3600")
+- **-al** - adjectival/system descriptor (e.g., dekal = "decimal/ten-based", maal = "sexagesimal")
+
+### System Naming Conventions
+
+The -al suffix creates terms for number systems and properties:
+- **hyxadekimal** = base-60 system (traditional mathematical style)
+- **hyxadekal** = base-60 system (pure Hyxos grammar)
+- **maal** = sexagesimal/sixty-based (from ma + al)
+- **sheal** = duodecimal/twelve-based
+- **dekal** = decimal/ten-based
+
+### Usage in Natural Languages
+
+These numerical expressions integrate into any language like specialized counting terms:
+- English: "Give me treeat apples" (Give me three each)
+- Spanish: "Necesito beyoos" (I need two each/in pairs)
+- Japanese: "Hyxan onegaishimasu" (Six times, please)
+- French: "J'en veux dekun" (I want tenfold)
+
+### Usage Notes
+
+- These suffixes modify meaning, not value: **beyma** (2×60=120) vs **beyema** (repeatedly two)
+- The -as (singular) suffix is typically implicit, like the ta diacritic
+- This system is provisional and may evolve with usage
+
+---
+
+## 9. Notes
+
+- Diacritic vowel order mirrors symbolic logic: a, e, i, o, u
+- Root glyphs can combine recursively with suffix tiers for massive numbers
+- Contractions enhance fluidity and spoken cadence
+- Hyxamel representations are typically much more concise than decimal equivalents (e.g., "feshexmaneyn" = 4 syllables vs "four thousand six hundred eighty-nine" = 9 syllables)
+
+---
+
+## 10. Diacritic Semantics and Silent `ta`
+
+### 🔹 The Silent Diacritic: `ta`
+
+The first 12 numerals (`zo` through `lev`, values 0–11) fall under an **implied diacritic**:
+
+- This diacritic is named **`ta`**
+- **It is not spoken or written**
+- **It defines the zeroth tier** of counting in the system
+
+Examples:
+- `ta.zo` = **zo**
+- `ta.zee` = **zee**
+- ...
+- `ta.lev` = **lev**
+
+> The `ta` diacritic is always **silent** and **invisible** in spoken or written form.
+
+### 🔹 The Zero Parallel: `ta` and `zo`
+
+There is a fundamental symmetry in the Hyxos system between zeros:
+
+- **`ta`** = Zero diacritic (represents tier 0)
+- **`zo`** = Zero glyph (represents value 0)
+
+This parallel creates a conceptual foundation:
+- Just as `zo` is the starting point for glyphs (0-11)
+- `ta` is the starting point for diacritics (tier 0)
+
+Both represent "nothing" or "zero" in their respective domains:
+- `ta` + any glyph = just the glyph (no diacritic modifier)
+- any diacritic + `zo` = just the diacritic value (e.g., `she` = 12, not `shezo`)
+
+---
+
+### 🔹 Diacritics as Powers of 12
+
+The five vowel-based diacritics reflect **powers of 12**:
+
+| Power of 12 | Decimal | Diacritic | Notes                     |
+|-------------|---------|-----------|---------------------------|
+| 12⁰         | 1       | `ta`      | (implied) base glyphs     |
+| 12¹         | 12      | `shey`    | `shezo` → spoken as `she` |
+| 12²         | 144     | `ree`     | `reezo` → spoken as `ree` |
+| 12³         | 1,728   | `jo`      | `jozo` → spoken as `jo`   |
+| 12⁴         | 20,736  | `wu`      | `wuzo` → spoken as `wu`   |
+
+Thus, the **diacritic alone** may serve as a numeral in multiples of 12:
+
+- **12** = `she` (not `shezo`)
+- **24** = `ree` (not `reezo`)
+- **36** = `jo`  (not `jozo`)
+- **48** = `wu`  (not `wuzo`)
+
+These shortenings improve clarity and rhythm in both speech and symbolic notation.
+
+---
+
+## 11. Practical Example: Math Problem
+
+Here's how Hyxos works in a real mathematical context:
+
+**Problem**: "If you have treema apples and need to distribute them hyxat to some baskets, then give away beyus through hyxus baskets, how many apples remain?"
+
+| Step | Description       | Hyxos | Calculation | Decimal |
+|------|-------------------|--------|-------------|---------|
+| 1    | Starting apples   | treema | tree × ma | 180 |
+| 2    | Distribute by     | hyxat | (by sixes) | ÷6 |
+| 3    | Number of baskets | reex | treema ÷ hyx | 30 |
+| 4    | Apples per basket | hyx | - | 6 |
+| 5    | Give away baskets | beyus through hyxus | - | 2nd-6th |
+| 6    | Baskets given     | pen | hyxus - zeeus | 5 |
+| 7    | Apples given away | reex | pen × hyx | 30 |
+| 8    | Apples remaining  | beymareex | treema - reex | 150 |
+
+**Answer**: beymareex apples remain
+
+This example demonstrates:
+- Cardinal numbers (treema, hyx, pen)
+- Ordinal suffixes (beyus, hyxus)
+- Distributive suffix (hyxat)
+- Arithmetic operations in hyxadekimal
+
+---
+
+## 12. Encoding
+
+The Hyxos numeral system supports two primary symbolic encodings:
+
+* **Base-12 Encoding** — for values `0` to `11`
+* **Sexagesimal Encoding** — for values `0` to `59`
+
+Encoding representations are designed for compact symbolic notation in digital or script-based contexts.
+
+---
+
+### 🔹 Base-12 Encoding (0–11)
+
+Each of the twelve root glyphs maps to a single hexadecimal-like character:
+
+| Decimal | Glyph | Encoding |
+| ------- | ----- | -------- |
+| 0       | zo    | `0`      |
+| 1       | zee   | `1`      |
+| 2       | bey   | `2`      |
+| 3       | tree  | `3`      |
+| 4       | kat   | `4`      |
+| 5       | pen   | `5`      |
+| 6       | hyx   | `6`      |
+| 7       | sep   | `7`      |
+| 8       | awk   | `8`      |
+| 9       | neyn  | `9`      |
+| 10      | dek   | `a`      |
+| 11      | lev   | `b`      |
+
+> ⚠️ These encodings are used standalone only for values 0–11.
+
+---
+
+### 🔹 Sexagesimal Encoding (0–59)
+
+All values from `0` to `59` are encoded using **two characters**, where:
+
+* The **first character** encodes the **diacritic tier** (in base-12, multiples of 12)
+* The **second character** encodes the **base glyph** (0–11)
+
+| Tier | Decimal Range | Diacritic | Encoding Char |
+| ---- | ------------- | --------- | ------------- |
+| 0    | 0–11          | ta        | `t`           |
+| 1    | 12–23         | she       | `s`           |
+| 2    | 24–35         | ree       | `r`           |
+| 3    | 36–47         | jo        | `j`           |
+| 4    | 48–59         | wu        | `w`           |
+
+#### Examples
+
+| Value | Spoken Form | Encoding |
+| ----- | ----------- | -------- |
+| 0     | zo          | `t0`     |
+| 3     | tree        | `t3`     |
+| 15    | shetree     | `s3`     |
+| 18    | shex        | `s6`     |
+| 32    | reek        | `r8`     |
+| 48    | wu          | `w0`     |
+| 59    | wulev       | `wb`     |
+
+> 💡 **Note:** Even single-digit values (like `zo`, `zee`) use two-character encodings when in sexagesimal context.
+
+---

--- a/README.MD
+++ b/README.MD
@@ -1,3 +1,165 @@
 # Hyxos Numerals
 
-A library for working with the *hyxos numerals*.
+A Rust library for working with the Hyxos numeral system - a base-60 (sexagesimal) counting system with linguistic elegance and mathematical precision.
+
+📖 **[Read the complete Grammar Guide](./GRAMMAR.md)** - The authoritative reference for the Hyxos numeral system
+
+## Overview
+
+The Hyxos system is designed as a pure numeral system that can be embedded within any existing language, similar to how terms like "dozen" or "score" function in English. It features:
+
+- **Base-60 structure** with 12 glyphs and 5 diacritics
+- **Phonetic contractions** for smoother pronunciation
+- **Suffix tiers** for large numbers (powers of 60)
+- **Grammatical suffixes** for plurals, ordinals, fractions, etc.
+- **Self-referential naming** - "hyxos" means 1/6 in the system itself
+
+## Quick Start
+
+```rust
+use hyxos_numerals::Numeral;
+
+// Create numerals
+let six = Numeral::new(6);
+assert_eq!(six.spoken_name(), "hyx");
+
+let thirty = Numeral::new(30);
+assert_eq!(thirty.spoken_name(), "reex"); // Contraction of ree + hyx
+
+// Encoding
+let fifteen = Numeral::new(15);
+assert_eq!(fifteen.encoding(), "s3"); // she (tier 1) + tree (offset 3)
+
+// Fractions
+assert_eq!(six.fractional_name(), "hyxos"); // One-sixth
+```
+
+## Grammar Guide
+
+### Terminology
+
+- **Hyxamel**: A number expressed in the Hyxos system
+- **Hyxadekimal/Maal**: The base-60 system itself
+- **[tier, offset]**: Two-part representation where tier (0-4) × 12 + offset (0-11) = decimal
+
+### Base Glyphs (0-11)
+
+| Decimal | Glyph | Encoding |
+|---------|-------|----------|
+| 0       | zo    | 0        |
+| 1       | zee   | 1        |
+| 2       | bey   | 2        |
+| 3       | tree  | 3        |
+| 4       | kat   | 4        |
+| 5       | pen   | 5        |
+| 6       | hyx   | 6        |
+| 7       | sep   | 7        |
+| 8       | awk   | 8        |
+| 9       | neyn  | 9        |
+| 10      | dek   | a        |
+| 11      | lev   | b        |
+
+### Diacritics (12-59)
+
+| Tier | Diacritic | Starts At | Encoding |
+|------|-----------|-----------|----------|
+| 0    | ta        | 0         | t        |
+| 1    | she       | 12        | s        |
+| 2    | ree       | 24        | r        |
+| 3    | jo        | 36        | j        |
+| 4    | wu        | 48        | w        |
+
+Examples:
+- 12 = **she** (not shezo)
+- 15 = **shetree**
+- 32 = **reek** (contraction)
+- 59 = **wulev**
+
+### Contractions
+
+For smoother pronunciation, `hyx` and `awk` contract with diacritics:
+
+| Diacritic | + hyx → | + awk → |
+|-----------|---------|---------|
+| she       | shex    | shek    |
+| ree       | reex    | reek    |
+| jo        | jox     | jok     |
+| wu        | wux     | wuk     |
+
+### Numbers ≥ 60
+
+Numbers follow the pattern: **[multiplier].[suffix].[remainder]**
+
+- 60 = **ma** (implicit ta.ma.zo)
+- 120 = **beyma** (2×60)
+- 150 = **beymareex** (2×60 + 30)
+- 3600 = **fe** (60²)
+
+### Fractions
+
+Add **-os** or **-tos** suffix:
+
+| Form    | Meaning | Decimal |
+|---------|---------|---------|
+| hyxos   | 1/6     | ~0.167  |
+| treetos | 1/3     | ~0.333  |
+| beytos  | 1/2     | 0.5     |
+
+### Grammatical Suffixes
+
+| Suffix | Function    | Example | Meaning        |
+|--------|-------------|---------|----------------|
+| -es    | plural      | hyxes   | sixes         |
+| -is    | trio        | hyxis   | group of three |
+| -us    | ordinal     | hyxus   | sixth         |
+| -an    | multiplicative | hyxan | sixfold      |
+| -al    | adjectival  | maal    | sexagesimal   |
+
+## API Reference
+
+### Creating Numerals
+
+```rust
+// From decimal (0-59)
+let n = Numeral::new(15);
+
+// From encoding
+let n = Numeral::new_from_enc("s3"); // 15
+```
+
+### Properties
+
+```rust
+let n = Numeral::new(32); // reek
+
+// Basic properties
+n.u();                    // 32 (decimal value)
+n.spoken_name();          // "reek" (with contractions)
+n.encoding();             // "r8"
+
+// Tier/offset breakdown
+n.diacritic_index();      // 2 (tier)
+n.duodecimal_index();     // 8 (offset)
+
+// Names
+n.diacritic_name();       // "ree"
+n.duodecimal_name();      // "awk"
+n.fractional_name();      // "awktos"
+
+// Cultural associations
+n.element();              // "fire"
+n.animal();               // "horse"
+n.color();                // "red"
+```
+
+## Contributing
+
+This library implements the Hyxos grammar as documented. When making changes:
+
+1. Ensure consistency with the grammar guide
+2. Add tests for new features
+3. Update documentation
+
+## License
+
+[License information here]

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,10 +1,10 @@
 pub mod constants {
     pub const DIACRITIC_CHARS: [char; 5] = ['t', 's', 'r', 'j', 'w'];
-    pub const DIACRITIC_NAME: [&str; 5] = ["ta", "she", "ri", "jo", "wu"];
+    pub const DIACRITIC_NAME: [&str; 5] = ["ta", "she", "ree", "jo", "wu"];
     pub const DUODECIMALS: [char; 12] =
-        ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B'];
+        ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b'];
     pub const DUODECIMAL_NAME: [&str; 12] = [
-        "zo", "zee", "bey", "tree", "kat", "pen", "hyx", "sep", "awk", "nen", "dek", "lev",
+        "zo", "zee", "bey", "tree", "kat", "pen", "hyx", "sep", "awk", "neyn", "dek", "lev",
     ];
     pub const COLORS: [&str; 5] = ["yellow", "blue", "red", "purple", "green"];
     pub const PLANETS: [&str; 5] = ["Saturn", "Mercury", "Mars", "Venus", "Jupiter"];
@@ -40,4 +40,35 @@ pub mod constants {
     pub const POLARITY: [&str; 2] = ["yin", "yang"];
     pub const POLARITY_CN: [&str; 2] = ["陰", "陽"];
     pub const POLARITY_LUMINARIES: [&str; 2] = ["Moon", "Sun"];
+    
+    // Suffix tier system for powers of 60
+    pub const SUFFIX_NAMES: [&str; 13] = [
+        "ma", "fe", "gi", "tho", "vu", "ya", "fre", "gli", "dra", "ske", "pri", "kro", "zru"
+    ];
+    pub const SUFFIX_POWERS: [u128; 13] = [
+        60,                 // 60^1
+        3_600,              // 60^2
+        216_000,            // 60^3
+        12_960_000,         // 60^4
+        777_600_000,        // 60^5
+        46_656_000_000,     // 60^6
+        2_799_360_000_000,  // 60^7
+        167_961_600_000_000, // 60^8
+        10_077_696_000_000_000, // 60^9
+        604_661_760_000_000_000, // 60^10
+        36_279_705_600_000_000_000, // 60^11
+        2_176_782_336_000_000_000_000, // 60^12
+        130_606_940_160_000_000_000_000, // 60^13
+    ];
+    
+    // Grammatical suffixes
+    pub const GRAMMATICAL_SUFFIXES: [&str; 11] = [
+        "as", "es", "is", "os", "us", "ema", "ek", "an", "at", "ar", "al"
+    ];
+    
+    // Fractional suffix rules
+    pub const FRACTIONAL_TOS: [&str; 12] = [
+        "zotos", "zeetos", "beytos", "treetos", "katos", "pentos", 
+        "hyxos", "septos", "awktos", "neynos", "dekos", "levos"
+    ];
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,27 @@ impl Numeral {
     pub fn sexagesimal_name(&self) -> String {
         self.diacritic_name().to_owned() + self.duodecimal_name()
     }
+    
+    pub fn spoken_name(&self) -> String {
+        match (self.diacritic_index(), self.duodecimal_index()) {
+            // ta tier - just the glyph name
+            (0, _) => self.duodecimal_name().to_string(),
+            // diacritic + zo = just the diacritic
+            (_, 0) => self.diacritic_name().to_string(),
+            // Contractions with hyx (6)
+            (1, 6) => "shex".to_string(),
+            (2, 6) => "reex".to_string(),
+            (3, 6) => "jox".to_string(),
+            (4, 6) => "wux".to_string(),
+            // Contractions with awk (8)
+            (1, 8) => "shek".to_string(),
+            (2, 8) => "reek".to_string(),
+            (3, 8) => "jok".to_string(),
+            (4, 8) => "wuk".to_string(),
+            // Default: diacritic + glyph
+            _ => self.diacritic_name().to_owned() + self.duodecimal_name()
+        }
+    }
     pub fn encoding(&self) -> String {
         self.diacritic_char().to_string() + &self.duodecimal_char().to_string()
     }
@@ -116,6 +137,10 @@ impl Numeral {
     }
     pub fn nickname_cn(&self) -> String {
         self.element_cn().to_string() + &self.animal_cn()
+    }
+    
+    pub fn fractional_name(&self) -> &str {
+        FRACTIONAL_TOS[self.duodecimal_index() as usize]
     }
     pub fn ganzhi(&self) -> String {
         self.heavenly_stem().to_string() + &self.earthly_branch()

--- a/tests/grammar_tests.rs
+++ b/tests/grammar_tests.rs
@@ -1,0 +1,107 @@
+#[cfg(test)]
+mod grammar_tests {
+    use hyxos_numerals::*;
+
+    #[test]
+    fn test_base_glyph_names() {
+        // Test all base glyphs (0-11)
+        let names = vec![
+            "zo", "zee", "bey", "tree", "kat", "pen", 
+            "hyx", "sep", "awk", "neyn", "dek", "lev"
+        ];
+        
+        for (i, expected) in names.iter().enumerate() {
+            let n = Numeral::new(i as u8);
+            assert_eq!(n.spoken_name(), *expected);
+            assert_eq!(n.duodecimal_name(), *expected);
+        }
+    }
+
+    #[test]
+    fn test_diacritic_names() {
+        // Test diacritic names match our grammar
+        assert_eq!(Numeral::new(12).spoken_name(), "she");
+        assert_eq!(Numeral::new(24).spoken_name(), "ree");
+        assert_eq!(Numeral::new(36).spoken_name(), "jo");
+        assert_eq!(Numeral::new(48).spoken_name(), "wu");
+    }
+
+    #[test]
+    fn test_contractions() {
+        // Test hyx contractions
+        assert_eq!(Numeral::new(18).spoken_name(), "shex");  // she + hyx
+        assert_eq!(Numeral::new(30).spoken_name(), "reex");  // ree + hyx
+        assert_eq!(Numeral::new(42).spoken_name(), "jox");   // jo + hyx
+        assert_eq!(Numeral::new(54).spoken_name(), "wux");   // wu + hyx
+        
+        // Test awk contractions
+        assert_eq!(Numeral::new(20).spoken_name(), "shek");  // she + awk
+        assert_eq!(Numeral::new(32).spoken_name(), "reek");  // ree + awk
+        assert_eq!(Numeral::new(44).spoken_name(), "jok");   // jo + awk
+        assert_eq!(Numeral::new(56).spoken_name(), "wuk");   // wu + awk
+    }
+
+    #[test]
+    fn test_encoding() {
+        // Test two-character encoding
+        assert_eq!(Numeral::new(0).encoding(), "t0");   // ta + zo
+        assert_eq!(Numeral::new(12).encoding(), "s0");  // she + zo
+        assert_eq!(Numeral::new(15).encoding(), "s3");  // she + tree
+        assert_eq!(Numeral::new(32).encoding(), "r8");  // ree + awk
+        assert_eq!(Numeral::new(59).encoding(), "wb");  // wu + lev
+    }
+
+    #[test]
+    fn test_fractional_names() {
+        // Test fractional forms
+        assert_eq!(Numeral::new(0).fractional_name(), "zotos");
+        assert_eq!(Numeral::new(1).fractional_name(), "zeetos");
+        assert_eq!(Numeral::new(2).fractional_name(), "beytos");
+        assert_eq!(Numeral::new(3).fractional_name(), "treetos");
+        assert_eq!(Numeral::new(4).fractional_name(), "katos");
+        assert_eq!(Numeral::new(5).fractional_name(), "pentos");
+        assert_eq!(Numeral::new(6).fractional_name(), "hyxos");
+        assert_eq!(Numeral::new(7).fractional_name(), "septos");
+        assert_eq!(Numeral::new(8).fractional_name(), "awktos");
+        assert_eq!(Numeral::new(9).fractional_name(), "neynos");
+        assert_eq!(Numeral::new(10).fractional_name(), "dekos");
+        assert_eq!(Numeral::new(11).fractional_name(), "levos");
+    }
+
+    #[test]
+    fn test_from_encoding() {
+        // Test parsing from encoding
+        assert_eq!(Numeral::new_from_enc("t0").u(), 0);
+        assert_eq!(Numeral::new_from_enc("s0").u(), 12);
+        assert_eq!(Numeral::new_from_enc("s3").u(), 15);
+        assert_eq!(Numeral::new_from_enc("r8").u(), 32);
+        assert_eq!(Numeral::new_from_enc("wb").u(), 59);
+    }
+
+    #[test]
+    fn test_tier_offset_calculation() {
+        // Test [tier, offset] breakdown
+        let n = Numeral::new(15); // shetree = [1, 3]
+        assert_eq!(n.diacritic_index(), 1);  // tier
+        assert_eq!(n.duodecimal_index(), 3); // offset
+        
+        let n = Numeral::new(32); // reek = [2, 8]
+        assert_eq!(n.diacritic_index(), 2);
+        assert_eq!(n.duodecimal_index(), 8);
+    }
+
+    #[test]
+    fn test_spoken_names_0_to_60() {
+        // Test critical transitions
+        let expected = vec![
+            (0, "zo"), (11, "lev"), (12, "she"), (13, "shezee"),
+            (18, "shex"), (20, "shek"), (24, "ree"), (30, "reex"),
+            (32, "reek"), (36, "jo"), (42, "jox"), (44, "jok"),
+            (48, "wu"), (54, "wux"), (56, "wuk"), (59, "wulev")
+        ];
+        
+        for (num, name) in expected {
+            assert_eq!(Numeral::new(num).spoken_name(), name);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds complete grammar documentation as GRAMMAR.md
- Fixes implementation to match documented grammar rules
- Includes comprehensive test suite

## Changes

### Documentation
- Added GRAMMAR.md as the authoritative reference for the Hyxos numeral system
- Updated README.md with grammar summary and prominent link to full guide
- Documents all features: base glyphs, diacritics, contractions, suffixes, fractions, and grammatical modifiers

### Implementation Fixes
- Fixed base names: 'ree' (was 'ri'), 'neyn' (was 'nen')
- Fixed encoding: lowercase 'a' and 'b' for decimal 10-11
- Added `spoken_name()` method with contraction support
- Added `fractional_name()` method for -os/-tos forms
- Added constants for future features (suffix tiers, grammatical suffixes)

### Testing
- Created comprehensive test suite in tests/grammar_tests.rs
- Tests validate: base names, contractions, encoding, fractions, and more
- All 8 tests pass

## Test Plan
- [x] Run `cargo test grammar_tests` - all tests pass
- [x] Verify grammar guide examples match implementation
- [x] Check README link to GRAMMAR.md works correctly