### PR TITLE
Fix pronunciation: 'she' → 'shey'

### DIFF
--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -7,7 +7,7 @@ This document outlines the grammar rules of the **Hyxos numeral system**, enabli
 **Important**: The Hyxos system is designed as a pure numeral system that can be embedded within any existing language, similar to how terms like "dozen" or "score" function in English. This guide covers only numerical expressions - no verbs, sentence structure, or non-numeric vocabulary. Hyxos numbers can be used within English, Spanish, Mandarin, or any other language as a specialized counting system.
 
 ### Terminology
-- **Hyxamel** (noun): A number expressed in the Hyxos numeral system, analogous to how "decimal" refers to base-10 numbers
+- **Hyxamal** (noun): A number expressed in the Hyxos numeral system, analogous to how "decimal" refers to base-10 numbers
 - **Decimal**: Traditional base-10 representation (e.g., 4689)
 - **Hyxadekimal** (adjective/noun): The base-60 numeral system itself, from hyxa (six) + dek (ten) + -imal, literally "six-ten-al" (Hyxos-native term using the system's own vocabulary)
 - **Maal** (adjective/noun): Pure Hyxos term for base-60/sexagesimal, from ma (60) + -al suffix
@@ -204,7 +204,7 @@ Pattern observations:
 - **-os**: katos, hyxos, neynos, dekos, levos, shetos
 - The distribution may reflect phonetic harmony or historical linguistic patterns
 
-| Hyxamel | Meaning | Decimal |
+| Hyxamal | Meaning | Decimal |
 |---------|---------|---------|
 | zotos   | 1/0     | ∞       |
 | zeetos  | 1/1     | 1.0     |
@@ -287,7 +287,7 @@ These numerical expressions integrate into any language like specialized countin
 - Diacritic vowel order mirrors symbolic logic: a, e, i, o, u
 - Root glyphs can combine recursively with suffix tiers for massive numbers
 - Contractions enhance fluidity and spoken cadence
-- Hyxamel representations are typically much more concise than decimal equivalents (e.g., "feshexmaneyn" = 4 syllables vs "four thousand six hundred eighty-nine" = 9 syllables)
+- Hyxamal representations are typically much more concise than decimal equivalents (e.g., "feshexmaneyn" = 4 syllables vs "four thousand six hundred eighty-nine" = 9 syllables)
 
 ---
 

--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -41,15 +41,20 @@ Each diacritic represents a base-12 tier:
 | Tier | Diacritic | Starts At | Encoding |
 |------|-----------|-----------|----------|
 | 0    | ta        | 0         | t        |
-| 1    | she       | 12        | s        |
+| 1    | shey      | 12        | s        |
 | 2    | ree       | 24        | r        |
 | 3    | jo        | 36        | j        |
 | 4    | wu        | 48        | w        |
 
+**Important pronunciation rule for "shey"**: 
+- "shey" (rhymes with "way") stands alone when it represents 12
+- In compounds, the "y" is dropped: sheyzee → shezee, sheytree → shetree
+- This is why contractions show "shex" not "sheyx", "shek" not "sheyk"
+
 ### Encoding Methods
 
 1. **Two-Part Array Encoding**: [tier, offset] where tier is 0-4 and offset is 0-11
-   - `[1, 0]` = she (tier 1, offset 0 = decimal 12)
+   - `[1, 0]` = shey (tier 1, offset 0 = decimal 12)
    - `[1, 3]` = shetree (tier 1, offset 3 = decimal 15)
    - `[2, 8]` = reek (tier 2, offset 8 = decimal 32)
    - `[4, 0]` = wu (tier 4, offset 0 = decimal 48)

--- a/README.MD
+++ b/README.MD
@@ -38,7 +38,7 @@ assert_eq!(six.fractional_name(), "hyxos"); // One-sixth
 
 ### Terminology
 
-- **Hyxamel**: A number expressed in the Hyxos system
+- **Hyxamal**: A number expressed in the Hyxos system
 - **Hyxadekimal/Maal**: The base-60 system itself
 - **[tier, offset]**: Two-part representation where tier (0-4) × 12 + offset (0-11) = decimal
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,6 +1,6 @@
 pub mod constants {
     pub const DIACRITIC_CHARS: [char; 5] = ['t', 's', 'r', 'j', 'w'];
-    pub const DIACRITIC_NAME: [&str; 5] = ["ta", "she", "ree", "jo", "wu"];
+    pub const DIACRITIC_NAME: [&str; 5] = ["ta", "shey", "ree", "jo", "wu"];
     pub const DUODECIMALS: [char; 12] =
         ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b'];
     pub const DUODECIMAL_NAME: [&str; 12] = [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,8 @@ impl Numeral {
             (3, 8) => "jok".to_string(),
             (4, 8) => "wuk".to_string(),
             // Default: diacritic + glyph
+            // Special case for shey tier - drop the "y" in compounds
+            (1, _) => "she".to_owned() + self.duodecimal_name(),
             _ => self.diacritic_name().to_owned() + self.duodecimal_name()
         }
     }

--- a/tests/grammar_tests.rs
+++ b/tests/grammar_tests.rs
@@ -20,7 +20,7 @@ mod grammar_tests {
     #[test]
     fn test_diacritic_names() {
         // Test diacritic names match our grammar
-        assert_eq!(Numeral::new(12).spoken_name(), "she");
+        assert_eq!(Numeral::new(12).spoken_name(), "shey");
         assert_eq!(Numeral::new(24).spoken_name(), "ree");
         assert_eq!(Numeral::new(36).spoken_name(), "jo");
         assert_eq!(Numeral::new(48).spoken_name(), "wu");
@@ -94,7 +94,7 @@ mod grammar_tests {
     fn test_spoken_names_0_to_60() {
         // Test critical transitions
         let expected = vec![
-            (0, "zo"), (11, "lev"), (12, "she"), (13, "shezee"),
+            (0, "zo"), (11, "lev"), (12, "shey"), (13, "shezee"),
             (18, "shex"), (20, "shek"), (24, "ree"), (30, "reex"),
             (32, "reek"), (36, "jo"), (42, "jox"), (44, "jok"),
             (48, "wu"), (54, "wux"), (56, "wuk"), (59, "wulev")


### PR DESCRIPTION
## Summary
Updates the diacritic name from 'she' to 'shey' for correct pronunciation throughout the codebase.

## Changes
- Updated `DIACRITIC_NAME` in constants.rs: "she" → "shey"  
- Fixed `spoken_name()` implementation to drop 'y' in compounds (shey → she)
- Updated all references in GRAMMAR.md to use "shey"
- Fixed test expectations in grammar_tests.rs
- Added explicit pronunciation rule in grammar guide

## Key Pronunciation Rules
- 'shey' rhymes with 'way' (not pronounced like English pronoun 'she')
- Stands alone as "shey" when representing 12
- The 'y' is dropped in compound forms: sheyzee → shezee, sheytree → shetree
- This is why contractions show "shex" not "sheyx", "shek" not "sheyk"

## Test Plan
- [x] Code compiles successfully
- [x] All grammar tests pass
- [x] spoken_name() correctly returns "shezee" for 13, not "sheyzee"
- [x] Pronunciation rule is clearly documented in GRAMMAR.md